### PR TITLE
Fix desktop file deprecations.

### DIFF
--- a/extra_files/gtk-gnutella.desktop
+++ b/extra_files/gtk-gnutella.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Version=1.0
-Encoding=UTF-8
 Name=gtk-gnutella
 Name[de]=gtk-gnutella
 Name[fr]=gtk-gnutella
@@ -33,5 +32,5 @@ Exec=gtk-gnutella
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=GTK;Application;Network;FileTransfer;P2P;
-Icon=gtk-gnutella.png
+Categories=GTK;Network;FileTransfer;P2P;
+Icon=gtk-gnutella


### PR DESCRIPTION
Fix warnings provided by the desktop-file-validate tool:
- Encoding key and Application category are deprecated.
- Icons should not have an extension if the path is not absolute.
