### PR TITLE
Don't embed build date if SOURCE_DATE_EPOCH is set for reproducibile builds

### DIFF
--- a/scripts/nm-list
+++ b/scripts/nm-list
@@ -54,7 +54,7 @@ da39a3ee5e6b4b0d3255bfef95601890afd80709) ;;
 *) SHA1SUM=$TOP/src/bin/sha1sum ;;
 esac
 
-date=`date`
+date=`date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}"`
 sha1=`$SHA1SUM $file 2>/dev/null | cut -f1 -d' '`
 case "$sha1" in
 '')	echo "Failed to compute SHA1 of $file" >&2; exit 1;;


### PR DESCRIPTION
See <https://reproducible-builds.org/specs/source-date-epoch/> for more
details about this variable.

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>