### PR TITLE
Rename statx struct to statistics

### DIFF
--- a/src/lib/stats.c
+++ b/src/lib/stats.c
@@ -50,7 +50,7 @@ enum statx_magic { STATX_MAGIC = 0x560044e5 };
 /**
  * A one-dimension container (x).
  */
-struct statx {
+struct statistics {
 	enum statx_magic magic;	/**< Magic number */
 	elist_t data;			/**< Data points */
 	long n;					/**< Amount of data points */
@@ -60,7 +60,7 @@ struct statx {
 };
 
 static inline void
-statx_check(const struct statx * const sx)
+statx_check(const struct statistics * const sx)
 {
 	g_assert(sx != NULL);
 	g_assert(STATX_MAGIC == sx->magic);

--- a/src/lib/stats.h
+++ b/src/lib/stats.h
@@ -40,9 +40,9 @@
  * One dimension statistics.
  */
 
-struct statx;
+struct statistics;
 
-typedef struct statx statx_t;
+typedef struct statistics statx_t;
 
 statx_t *statx_make(void);
 statx_t *statx_make_nodata(void);


### PR DESCRIPTION
glibc 2.28 introduces a statx struct and this causes a namespace
collision at compile time. Renaming the struct avoids this issue.

Fixes: #549 and #550