### PR TITLE
search_gui_close_search(): avoid crash when emptying search list twice.

### DIFF
--- a/src/ui/gtk/gtk-shared/callbacks.c
+++ b/src/ui/gtk/gtk-shared/callbacks.c
@@ -309,6 +309,7 @@ directory_chooser_show(enum dir_choice dir_choice, const char *title,
 	const char *current_directory)
 {
 	GtkWidget *widget;
+	GtkFileFilter *filter;
 
 	if (directory_chooser) {
 		gtk_widget_destroy(directory_chooser);
@@ -324,9 +325,13 @@ directory_chooser_show(enum dir_choice dir_choice, const char *title,
 	g_return_if_fail(NULL != widget);
 	directory_chooser = widget;
 
+	filter = gtk_file_filter_new();
+	gtk_file_filter_add_mime_type(filter, "inode/directory");
+
+
 	gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(widget), TRUE);
 	gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(widget),
-		gtk_file_filter_new());	/* Display only directories */
+		filter);	/* Display only directories */
 
 	if (NULL != current_directory) {
 		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(widget),

--- a/src/ui/gtk/search_common.c
+++ b/src/ui/gtk/search_common.c
@@ -716,9 +716,7 @@ search_gui_clear_results(void)
 	search_gui_update_status(search);
 }
 
-
-static void
-search_gui_switch_search(struct search *search);
+static void search_gui_switch_search(struct search *search);
 
 /**
  * Remove the search from the list of searches and free all

--- a/src/ui/gtk/search_common.c
+++ b/src/ui/gtk/search_common.c
@@ -716,6 +716,10 @@ search_gui_clear_results(void)
 	search_gui_update_status(search);
 }
 
+
+static void
+search_gui_switch_search(struct search *search);
+
 /**
  * Remove the search from the list of searches and free all
  * associated resources (including filter and gui stuff).
@@ -763,7 +767,12 @@ search_gui_close_search(search_t *search)
 
 	n = gtk_notebook_page_num(notebook_search_results, search->scrolled_window);
 	g_assert(n >= 0);	/* Must be found! */
-	gtk_notebook_remove_page(notebook_search_results, n);
+	if (gtk_notebook_get_n_pages(notebook_search_results) != 1)
+		gtk_notebook_remove_page(notebook_search_results, n);
+	else {
+		gtk_widget_set_sensitive(search->tree, FALSE);
+		search_gui_switch_search(NULL);
+	}
 
 	hset_free_null(&search->dups);
 	htable_free_null(&search->parents);


### PR DESCRIPTION
It looks like notebook_search_results should never be emptyed. We can
avoid it being emtpy handlig this special case in search_gui_close_search
by insensityzing current search tree and calling
search_gui_switch_search(NULL).