### PR TITLE
Fix build on NetBSD with SSP

### DIFF
--- a/src/core/bogons.c
+++ b/src/core/bogons.c
@@ -81,7 +81,7 @@ bogons_load(FILE *f)
 		bogons_mtime = buf.st_mtime;
 	}
 
-	while (fgets(ARYLEN(line), f)) {
+	while (fgets(line, sizeof(line), f)) {
 		linenum++;
 
 		/*

--- a/src/core/dmesh.c
+++ b/src/core/dmesh.c
@@ -3372,7 +3372,7 @@ dmesh_retrieve(void)
 	 * blank line are attached sources for this SHA1.
 	 */
 
-	while (fgets(ARYLEN(tmp), f)) {
+	while (fgets(tmp, sizeof(tmp), f)) {
 		if (!file_line_chomp_tail(ARYLEN(tmp), NULL)) {
 			truncated = TRUE;
 			continue;
@@ -3486,7 +3486,7 @@ dmesh_ban_retrieve(void)
 	 * Lines starting with a # are skipped.
 	 */
 
-	while (fgets(ARYLEN(tmp), in)) {
+	while (fgets(tmp, sizeof(tmp), in)) {
 		line++;
 
 		if (!file_line_chomp_tail(ARYLEN(tmp), NULL)) {

--- a/src/core/downloads.c
+++ b/src/core/downloads.c
@@ -15067,7 +15067,7 @@ download_retrieve_old(FILE *f)
 	d_name = NULL;
 	flags = 0;
 
-	while (fgets(ARYLEN(dl_tmp), f)) {
+	while (fgets(dl_tmp, sizeof(dl_tmp), f)) {
 		line++;
 
 		if (!file_line_chomp_tail(ARYLEN(dl_tmp), NULL)) {

--- a/src/core/fileinfo.c
+++ b/src/core/fileinfo.c
@@ -3206,7 +3206,7 @@ file_info_retrieve(void)
 	if (!f)
 		return;
 
-	while (fgets(ARYLEN(line), f)) {
+	while (fgets(line, sizeof(line), f)) {
 		int error;
 		bool truncated = FALSE, damaged;
 		const char *ep;

--- a/src/core/g2/gwc.c
+++ b/src/core/g2/gwc.c
@@ -324,7 +324,7 @@ retry:
 	line = 0;
 	added = 0;
 
-	while (fgets(ARYLEN(tmp), in)) {
+	while (fgets(tmp, sizeof(tmp), in)) {
 		line++;
 
 		if (tmp[0] == '#')		/* Skip comments */

--- a/src/core/geo_ip.c
+++ b/src/core/geo_ip.c
@@ -435,7 +435,7 @@ gip_load(FILE *f, unsigned idx, const char *filename, bool initial)
 		gip_source[idx].mtime = buf.st_mtime;
 	}
 
-	while (fgets(ARYLEN(line), f)) {
+	while (fgets(line, sizeof(line), f)) {
 		linenum++;
 
 		/*

--- a/src/core/hcache.c
+++ b/src/core/hcache.c
@@ -1878,7 +1878,7 @@ hcache_load_file(hostcache_t *hc, FILE *f)
 	g_return_if_fail(f);
 
 	now = tm_time();
-	while (fgets(ARYLEN(buffer), f)) {
+	while (fgets(buffer, sizeof(buffer), f)) {
 		const char *endptr;
 		host_addr_t addr;
 		uint16 port;

--- a/src/core/hostiles.c
+++ b/src/core/hostiles.c
@@ -294,7 +294,7 @@ hostiles_load(FILE *f, hostiles_t which)
 
 	hostile_db[which] = iprange_new();
 
-	while (fgets(ARYLEN(line), f)) {
+	while (fgets(line, sizeof(line), f)) {
 		linenum++;
 
 		/*

--- a/src/core/huge.c
+++ b/src/core/huge.c
@@ -402,7 +402,7 @@ sha1_read_cache(void)
 		for (;;) {
 			char buffer[4096];
 
-			if (NULL == fgets(ARYLEN(buffer), f))
+			if (NULL == fgets(buffer, sizeof(buffer), f))
 				break;
 
 			if (!file_line_chomp_tail(ARYLEN(buffer), NULL)) {

--- a/src/core/ignore.c
+++ b/src/core/ignore.c
@@ -165,7 +165,7 @@ sha1_parse(FILE *f, const char *file)
 
 	g_assert(f);
 
-	while (fgets(ARYLEN(ign_tmp), f)) {
+	while (fgets(ign_tmp, sizeof(ign_tmp), f)) {
 		line++;
 
 		if (!file_line_chomp_tail(ARYLEN(ign_tmp), &len)) {
@@ -241,7 +241,7 @@ namesize_parse(FILE *f, const char *file)
 
 	g_assert(f);
 
-	while (fgets(ARYLEN(ign_tmp), f)) {
+	while (fgets(ign_tmp, sizeof(ign_tmp), f)) {
 		line++;
 
 		if (!file_line_chomp_tail(ARYLEN(ign_tmp), NULL)) {

--- a/src/core/ipp_cache.c
+++ b/src/core/ipp_cache.c
@@ -452,7 +452,7 @@ ipp_cache_parse(ipp_cache_t *ic, FILE *f)
 	bit_array_init(tag_used, NUM_IPP_CACHE_TAGS);
 	bit_array_clear_range(tag_used, 0, NUM_IPP_CACHE_TAGS - 1U);
 
-	while (fgets(ARYLEN(line), f)) {
+	while (fgets(line, sizeof(line), f)) {
 		const char *tag_name, *value;
 		char *sp;
 		bool damaged;

--- a/src/core/parq.c
+++ b/src/core/parq.c
@@ -5208,7 +5208,7 @@ parq_upload_load_queue(void)
 	entry = zero_entry;
 	bit_array_init(tag_used, NUM_PARQ_TAGS);
 
-	while (fgets(ARYLEN(line), f)) {
+	while (fgets(line, sizeof(line), f)) {
 		const char *tag_name, *value;
 		char *colon;
 		bool damaged;

--- a/src/core/spam.c
+++ b/src/core/spam.c
@@ -221,7 +221,7 @@ spam_load(FILE *f)
 	item = zero_item;
 	bit_array_init(tag_used, NUM_SPAM_TAGS);
 
-	while (fgets(ARYLEN(line), f)) {
+	while (fgets(line, sizeof(line), f)) {
 		const char *tag_name, *value;
 		char *sp;
 		spam_tag_t tag;

--- a/src/core/spam_sha1.c
+++ b/src/core/spam_sha1.c
@@ -199,7 +199,7 @@ spam_sha1_load(FILE *f)
 	spam_lut_create();
 	sha1_lut.state = SPAM_LOADING;
 
-	while (fgets(ARYLEN(line), f)) {
+	while (fgets(line, sizeof(line), f)) {
 		const struct sha1 *sha1;
 		size_t len;
 

--- a/src/core/upload_stats.c
+++ b/src/core/upload_stats.c
@@ -223,7 +223,7 @@ upload_stats_load_history(void)
 		goto done;
 
 	/* parse, insert names into ul_stats_clist */
-	while (fgets(ARYLEN(line), upload_stats_file)) {
+	while (fgets(line, sizeof(line), upload_stats_file)) {
 		static const struct ul_stats zero_item;
 		struct ul_stats item;
 		struct sha1 sha1_buf;

--- a/src/core/whitelist.c
+++ b/src/core/whitelist.c
@@ -339,7 +339,7 @@ whitelist_retrieve(void)
 		return;
 	}
 
-    while (fgets(ARYLEN(line), f)) {
+    while (fgets(line, sizeof(line), f)) {
 		pslist_t *sl_addr, *sl;
 		const char *endptr, *start;
 		host_addr_t addr;

--- a/src/dht/routing.c
+++ b/src/dht/routing.c
@@ -5376,7 +5376,7 @@ dht_route_parse(FILE *f)
 	bit_array_init(tag_used, NUM_DHT_ROUTE_TAGS);
 	nodes = patricia_create(KUID_RAW_BITSIZE);
 
-	while (fgets(ARYLEN(line), f)) {
+	while (fgets(line, sizeof(line), f)) {
 		const char *tag_name, *value;
 		char *sp;
 		dht_route_tag_t tag;

--- a/src/lib/getgateway.c
+++ b/src/lib/getgateway.c
@@ -101,7 +101,7 @@ parse_netstat(host_addr_t *addrp)
 	 * output is "default" for the default route.
 	 */
 
-	while (fgets(ARYLEN(tmp), f)) {
+	while (fgets(tmp, sizeof(tmp), f)) {
 		char *p;
 		uint32 ip;
 

--- a/src/lib/prop.c
+++ b/src/lib/prop.c
@@ -2382,7 +2382,7 @@ prop_load_from_file(prop_set_t *ps, const char *dir, const char *filename)
 	 * ([[:blank:]]*)(("[^"]*")|([^[:space:]]*))
 	 *
 	 */
-	while (fgets(ARYLEN(prop_tmp), config)) {
+	while (fgets(prop_tmp, sizeof(prop_tmp), config)) {
 		char *s, *k, *v;
 		int c;
 		property_t prop;

--- a/src/lib/symbols.c
+++ b/src/lib/symbols.c
@@ -1553,7 +1553,7 @@ symbols_load_from(symbols_t *st, const char *exe, const  char *lpath)
 #endif	/* MINGW32 */
 
 retry:
-	while (fgets(ARYLEN(tmp), f)) {
+	while (fgets(tmp, sizeof(tmp), f)) {
 		symbols_parse_nm(st, tmp);
 	}
 

--- a/src/sdbm/tmp.c
+++ b/src/sdbm/tmp.c
@@ -219,7 +219,7 @@ tmp_clean_entries(int *fd, const char *ext, const DBM *db, const char *caller)
 	eslist_init(&items, offsetof(struct tmp_entry, next));
 	s = str_new(32);
 
-	while (fgets(ARYLEN(line), f)) {
+	while (fgets(line, sizeof(line), f)) {
 		char *extension;
 		pid_t pid;
 		struct tmp_entry *item;


### PR DESCRIPTION
`/usr/include/ssp/stdio.h` on NetBSD re-defines `fgets()`:
```
#define fgets(str, len, fp)     __fgets_chk(str, len, __ssp_bos(str), fp)
```
gtk-gnutella uses `ARYLEN()` a lot in `fgets()` calls, i.e.:
```
fgets(ARYLEN(tmp), bar)
```

These two macros do not interopate well, breaking the build on NetBSD.
I've expanded `ARYLEN()` in the `fgets()` calls to fix the build.