### PR TITLE
Avoid conflicting symbol with NetBSD's powerpc/frame.h

### DIFF
--- a/src/lib/memusage.c
+++ b/src/lib/memusage.c
@@ -535,11 +535,16 @@ memusage_set_stack_accounting(memusage_t *mu, bool on)
 	MEMUSAGE_THREAD_UNLOCK(mu);
 }
 
-struct callframe {
+/**
+ * On NetBSD/powerpc, a header file defines callframe already;
+ * work around this.
+*/
+struct my_callframe {
 	size_t calls;
 	const struct stackatom *frame;
 	const struct memusage_counter *mc;
 };
+#define callframe my_callframe
 
 /**
  * qsort() callback for sorting callframe items by decreasing call amount.


### PR DESCRIPTION
That file also defines a callframe symbol.

Another solution would be to rename the symbol 'callframe' in all places to `gg_callframe` or any other name - let me know if you prefer that solution, then we don't need a comment to explain it.