### PR TITLE
Fix atomic_lock_t for Darwin ppc32

### DIFF
--- a/src/coverity.c
+++ b/src/coverity.c
@@ -55,7 +55,13 @@ log_abort(void)
 }
 
 typedef unsigned char uint8;
-typedef volatile uint8 atomic_lock_t;
+typedef unsigned int uint32;
+
+#if defined(__APPLE__) && defined(__ppc__) /* Darwin PowerPC 32-bit ABI */
+    typedef volatile uint32 atomic_lock_t;
+#else
+    typedef volatile uint8 atomic_lock_t;
+#endif
 
 const bool TRUE = 1;
 const bool FALSE = 0;

--- a/src/lib/atomic.h
+++ b/src/lib/atomic.h
@@ -45,7 +45,11 @@
  * or we might loop forever.
  */
 
+#if defined(__APPLE__) && defined(__ppc__) /* Darwin PowerPC 32-bit ABI */
+typedef volatile uint32 atomic_lock_t;
+#else
 typedef volatile uint8 atomic_lock_t;
+#endif
 
 /*
  * Public interface.


### PR DESCRIPTION
@rmanfredi Or rather `int` is preferable, like it is defined for `bool` there?

P. S. Related, and links there: https://github.com/boostorg/smart_ptr/issues/105